### PR TITLE
Use index instead if 'dx' to access consumptionData

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2712,16 +2712,15 @@ function calcPowerAverages() {
         let cnt = 0;
         let sum = 0;
         for(let d = 0; d < 4; d++) {
-			let dx = 'd' + d;
-			if(!consumptionData[dn][dx]) {
-				consumptionData[dn][dx] = {
+			if(!consumptionData[dn][d]) {
+				consumptionData[dn][d] = {
 					samples: 0,
 					consumption: 0,
 					average: 0
 				};
 			}
 
-            let val = consumptionData[dn][dx].consumption;
+            let val = consumptionData[dn][d].consumption;
             if(val) {
                 cnt++;
                 sum += val;
@@ -2850,24 +2849,22 @@ function updatePowerConsumption(state) {
 	}
 
 	if(!consumptionData[dn]) {
-		consumptionData[dn] = {
-			d0: {}
-		};
-	} else if(!consumptionData[dn]['d0']) {
-		consumptionData[dn]['d0'] = {
+		consumptionData[dn] = {};
+	} else if(!consumptionData[dn][0]) {
+		consumptionData[dn][0] = {
 			average: 0,
 			samples: 0,
 			consumption: 0
 		};
 	}
-	let curavg = (consumptionData[dn]['d0'] ? consumptionData[dn]['d0'].average : 0);
-	let curcnt = (consumptionData[dn]['d0'] ? consumptionData[dn]['d0'].samples : 0);
+	let curavg = (consumptionData[dn][0] ? consumptionData[dn][0].average : 0);
+	let curcnt = (consumptionData[dn][0] ? consumptionData[dn][0].samples : 0);
 
 	let newavg = ((curavg * curcnt) + state.val) / (curcnt + 1);
 	curcnt++;
 
-	consumptionData[dn]['d0'].average = newavg;
-	consumptionData[dn]['d0'].samples = curcnt;
+	consumptionData[dn][0].average = newavg;
+	consumptionData[dn][0].samples = curcnt;
 
 	//* calc consumption
 	let now = new Date();
@@ -2889,7 +2886,7 @@ function updatePowerConsumption(state) {
 	} else {
 		power_sum = newavg * (24 - sun_hours);
 	}
-	consumptionData[dn]['d0'].consumption = power_sum;
+	consumptionData[dn][0].consumption = power_sum;
 
 	calcPowerAverages(); // no rotating please!
 }


### PR DESCRIPTION
I think this change resolved #51.

The access to consumption_data[][] was done with "d0", "d1", ... to update the values, but the structure was created only with index (no label). 
The solution without label is the format which is as well in the saved file. So that file and the data should be compatible now. 

To finally see if all aspects (e.g. rotation) work, the adapter need to run a few days. 
Nevertheless you may already have a look on the changes or test in parallel.