### PR TITLE
publish power_plus

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2344,10 +2344,9 @@ function calcMinSoC(forecastRead, tomorrow) {
 			let curSoC = 0;
 			let curSoCPercentage = 0;
 
-			adapter.getState('forecast.consumption.day', function(err, state) {
+			adapter.getState('forecast.consumption.remaining', function(err, state) {
 				if(!err) {
 					daily_cons = state.val;
-					daily_cons = daily_cons * powerHours / sun_hours;      // calculate the assumed remaining consumption
 				}
 
 				adapter.getState('devices.local.battery.SoC', function(err, state) {
@@ -2362,7 +2361,12 @@ function calcMinSoC(forecastRead, tomorrow) {
 							curMinSoC = (state ? state.val : null);
 						}
 
+						// calculate the power not use for average consumption or loading until sunset. After sunset it is always 0.
 						let power_plus = powerUntilSunset - daily_cons + curSoC - adapter.config.battery_capacity;
+						if (timeNow > sunset) {
+							power_plus = 0;
+						}
+
 						adapter.log.debug('Checking battery management: ' + power_plus + ' = ' + powerUntilSunset + ' - ' + daily_cons + ' + ' + curSoC + ' - ' + adapter.config.battery_capacity + ' > ' + panelWp + ' * ' + maxFeedInFactor + ' (' + (panelWp * maxFeedInFactor) + ') -> ' + enable_smart_battery_control);
 						/*if(power_plus <= panelWp * maxFeedInFactor) {
 							enable_smart_battery_control = false;
@@ -2378,6 +2382,7 @@ function calcMinSoC(forecastRead, tomorrow) {
 							enable_smart_battery_control = false;
 						}
 
+						// write battery.SmartBatteryControl
 						adapter.getState('devices.local.battery.SmartBatteryControl', function(err, state) {
 							if(!err) {
 								let curValue = (state ? state.val : null);
@@ -2388,12 +2393,24 @@ function calcMinSoC(forecastRead, tomorrow) {
 								}
 							}
 						});
-					});
 
+						// publish power_plus
+						ioBLib.createOrSetState('forecast.consumption.power_plus', {
+							type: 'state',
+							common: {
+								name: 'Free available power until sunset (adjusted forecast - remaining consumption - free battery capacity)',
+								type: 'number',
+								role: 'value.power',
+								read: true,
+								write: false,
+								unit: 'Wh'
+							},
+							native: {}
+						}, power_plus);
+					});
 				});
 			});
 		}
-		
 	}
 
 	if(doMinSoC === false) {


### PR DESCRIPTION
The data of the plenticore adapter are an important input to control some other devices (e.g. switching of heat pump). In some cases I needed the information which is calculated in the plenticore adapter as "power_plus". 
Instead of re-implementing the same calculation in different places (and because it may be useful as well for other users), I propose to publish the power_plus value. 

Changes done:
- remove redundant calculation of remaining consumption
- set to 0 after sunset
- publish power_plus