### PR TITLE
freeze forecast for complete day but update hourly forecast

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2117,50 +2117,52 @@ function calcMinSoC(forecastRead, tomorrow) {
 		powerTime.setUTCMinutes(powerTime.getUTCMinutes() + 5);
 	}
 
-	// hourly values are updated during the complete day; for hours in the past the forecast will not change anymore
+	// hourly values are updated during the complete day; for current hour and past hours the forecast will not change anymore
 	for(let shindex in sunhour_power) {
 		let num_sun_hour = shindex.slice(0, -1);
-		let fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power';
-		ioBLib.createOrSetState(fc_state_id, {
-			type: 'state',
-			common: {
-				name: 'Power forecast for sun hour ' + num_sun_hour + ' of day',
-				type: 'number',
-				role: 'value.power',
-				read: true,
-				write: false,
-				unit: 'Wh'
-			},
-			native: {}
-		}, sunhour_power[shindex]['rain']);
+		if (tomorrow || (sunhour_starts[shindex] > curTime) ) {
+			let fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power';
+			ioBLib.createOrSetState(fc_state_id, {
+				type: 'state',
+				common: {
+					name: 'Power forecast for sun hour ' + num_sun_hour + ' of day',
+					type: 'number',
+					role: 'value.power',
+					read: true,
+					write: false,
+					unit: 'Wh'
+				},
+				native: {}
+			}, sunhour_power[shindex]['rain']);
 
-		fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power_high';
-		ioBLib.createOrSetState(fc_state_id, {
-			type: 'state',
-			common: {
-				name: 'Power forecast for sun hour ' + num_sun_hour + ' of day (visibility 100%, no rain)',
-				type: 'number',
-				role: 'value.power',
-				read: true,
-				write: false,
-				unit: 'Wh'
-			},
-			native: {}
-		}, sunhour_power[shindex]['clouds']);
+			fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power_high';
+			ioBLib.createOrSetState(fc_state_id, {
+				type: 'state',
+				common: {
+					name: 'Power forecast for sun hour ' + num_sun_hour + ' of day (visibility 100%, no rain)',
+					type: 'number',
+					role: 'value.power',
+					read: true,
+					write: false,
+					unit: 'Wh'
+				},
+				native: {}
+			}, sunhour_power[shindex]['clouds']);
 
-		fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.time';
-		ioBLib.createOrSetState(fc_state_id, {
-			type: 'state',
-			common: {
-				name: 'Sun hour ' + num_sun_hour + ' starts at',
-				type: 'number',
-				role: 'date',
-				read: true,
-				write: false,
-				unit: ''
-			},
-			native: {}
-		}, sunhour_starts[shindex]);
+			fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.time';
+			ioBLib.createOrSetState(fc_state_id, {
+				type: 'state',
+				common: {
+					name: 'Sun hour ' + num_sun_hour + ' starts at',
+					type: 'number',
+					role: 'date',
+					read: true,
+					write: false,
+					unit: ''
+				},
+				native: {}
+			}, sunhour_starts[shindex]);
+		} 
 	}
 
 	// delete objects for all later hours (which are hours after sunset that do not exist)

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2117,53 +2117,53 @@ function calcMinSoC(forecastRead, tomorrow) {
 		powerTime.setUTCMinutes(powerTime.getUTCMinutes() + 5);
 	}
 
-	if(tomorrow || curTime.getTime() < sunrise.getTime()) {
-		for(let shindex in sunhour_power) {
-			let num_sun_hour = shindex.slice(0, -1);
-			let fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power';
-			ioBLib.createOrSetState(fc_state_id, {
-				type: 'state',
-				common: {
-					name: 'Power forecast for sun hour ' + num_sun_hour + ' of day',
-					type: 'number',
-					role: 'value.power',
-					read: true,
-					write: false,
-					unit: 'Wh'
-				},
-				native: {}
-			}, sunhour_power[shindex]['rain']);
+	// hourly values are updated during the complete day; for hours in the past the forecast will not change anymore
+	for(let shindex in sunhour_power) {
+		let num_sun_hour = shindex.slice(0, -1);
+		let fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power';
+		ioBLib.createOrSetState(fc_state_id, {
+			type: 'state',
+			common: {
+				name: 'Power forecast for sun hour ' + num_sun_hour + ' of day',
+				type: 'number',
+				role: 'value.power',
+				read: true,
+				write: false,
+				unit: 'Wh'
+			},
+			native: {}
+		}, sunhour_power[shindex]['rain']);
 
-			fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power_high';
-			ioBLib.createOrSetState(fc_state_id, {
-				type: 'state',
-				common: {
-					name: 'Power forecast for sun hour ' + num_sun_hour + ' of day (visibility 100%, no rain)',
-					type: 'number',
-					role: 'value.power',
-					read: true,
-					write: false,
-					unit: 'Wh'
-				},
-				native: {}
-			}, sunhour_power[shindex]['clouds']);
+		fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.power_high';
+		ioBLib.createOrSetState(fc_state_id, {
+			type: 'state',
+			common: {
+				name: 'Power forecast for sun hour ' + num_sun_hour + ' of day (visibility 100%, no rain)',
+				type: 'number',
+				role: 'value.power',
+				read: true,
+				write: false,
+				unit: 'Wh'
+			},
+			native: {}
+		}, sunhour_power[shindex]['clouds']);
 
-			fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.time';
-			ioBLib.createOrSetState(fc_state_id, {
-				type: 'state',
-				common: {
-					name: 'Sun hour ' + num_sun_hour + ' starts at',
-					type: 'number',
-					role: 'date',
-					read: true,
-					write: false,
-					unit: ''
-				},
-				native: {}
-			}, sunhour_starts[shindex]);
-		}
+		fc_state_id = 'forecast' + add_id + '.power.' + shindex + '.time';
+		ioBLib.createOrSetState(fc_state_id, {
+			type: 'state',
+			common: {
+				name: 'Sun hour ' + num_sun_hour + ' starts at',
+				type: 'number',
+				role: 'date',
+				read: true,
+				write: false,
+				unit: ''
+			},
+			native: {}
+		}, sunhour_starts[shindex]);
 	}
 
+	// delete objects for all later hours (which are hours after sunset that do not exist)
 	for(let p = sun_hour + 1; p <= 24; p++) {
 		adapter.log.debug('Delete object ' + 'forecast' + add_id + '.power.' + p + 'h.time');
 		ioBLib.delObjectIfExists('forecast' + add_id + '.power.' + p + 'h.time');
@@ -2172,7 +2172,7 @@ function calcMinSoC(forecastRead, tomorrow) {
 	};
 
     let state_id;
-	if(tomorrow || curTime.getTime() < sunrise.getTime()) {
+	if(tomorrow || curTime.getTime() < sunrise.getTime()) {     // value for the complete day are only updated until sunrise
 		state_id = 'forecast.day1.power.day';
 		if(tomorrow) {
 			state_id = 'forecast.day2.power.day';


### PR DESCRIPTION
I propose to modify the change done in commit f816ff2 (Nov 2021) in the following way:
- Freeze after sunrise the forecast values for the complete day (e.g. day1.power.day, day1.power.day_high)  (current behaviour as before)
- Update during the day the hourly values (day1.power.Xh.power, day1.power.Xh.power_high). This has already the following behaviour: all hours in the past stay unchanged, all hours starting from the current hour are updated with the latest forecast values. (changed behaviour)

With this change the day1.power.day_adjusted has always the most accurate forecast: for past hours it uses the actually generated power and for the remaining hours it uses the latest forecast information.