### PR TITLE
Battery strategy 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,28 @@ The forecast values can then be used to set the MinSoC of the battery, enable or
 `plenticore.0.forecast.day1.sun.sunrise` - sunrise time of forecast date  
 `plenticore.0.forecast.day1.sun.sunset` - sunset time of forecast date  
 
+## Smart battery control
+
+The smart battery control from KOSTAL does not use a weather forecast. Therefore, it does not always control ideally to ensure on the one hand that the battery is fully charged and on the other hand to avoind feed-in limitation as much as possible.
+This adapter tries to optimize this. Two strategies are offered for this, which can be selected in the settings of the adapter.
+
+### Strategy 1: Double day forecast vs. battery capacity
+
+Brief description: Switch smart battery management on, if (minimum SoC is reached) AND (remaining power until sunset - remaining consumption - free battery capacity) >= 2 * battery capacity.
+
+### Strategy 2: Remaining forecast vs. consumption and free battery capacity
+
+Brief description: Switch smart battery management on, if (minimum SoC is reached) AND (hours with forecast > maximum feedinpower) AND (remaining power until sunset - remaining consumption - free battery capacity) > 0"
+
+Details:
+- If all hourly forecast values ​​are lower than "Maximum feed-in", the KOSTAL control is not activated. The maximum feed-in is assumed 15% lower in order to anticipate variations caused by clouds.
+- Between 3 p.m. and sunrise, the setting of the KOSTAL smart control is not changed. The KOSTAL control seems to work better if it is not switched on/off unnecessarily often. During this period, the KOSTAL control has no disadvantage.
+- A hysteresis is used to switch on/off less often. It will turn off when the current SoC is less than the "Minimum SoC to activate battery management" or when the free power is below 0. It will turn on when the current SoC is greater than "Minimum SoC to activate battery management"+1 and the free power is greater than 10% of the battery capacity.
+
 ## Changelog
+
+### 2.2.2
+- Added alternative smart battery strategy (Description see above) [PastCoder]
 
 ### 2.2.1
 - Fixed forecast zickzack [PastCoder]

--- a/README_de.md
+++ b/README_de.md
@@ -167,7 +167,28 @@ Die Prognosewerte können dann verwendet werden, um den MinSoC der Batterie einz
 `plenticore.0.forecast.day1.sun.sunrise` - Sonnenaufgang des Vorhersagedatums  
 `plenticore.0.forecast.day1.sun.sunset` - Sonnenuntergang des Vorhersagedatums  
 
+## Intelligente Batteriesteuerung
+
+Die intelligente Batteriesteuerung von KOSTAL nutzt keine Wettervorhersage. Daher steuert sie nicht immer ideal, um einerseits den Ladung des Speicher sicherzustellen und andererseits möglichsten in die Abregelung zu kommen. 
+Dieser Adapter probiert dies zu optimieren. Hierfür werden zwei Strategien angeboten, welche in den Einstellungen des Adapter ausgewählt werden können.
+
+### Strategie 1: Double day forecast vs. battery capacity
+
+Kurzbeschreibung: Intelligentes Batteriemanagement einschalten, wenn (Mindest-SoC erreicht) UND (Restleistung bis Sonnenuntergang – Restverbrauch – freie Batteriekapazität) >= 2 * Batteriekapazität.
+
+### Strategie 2: Remaining forecast vs. consumption and free battery capacity
+
+Kurzbeschreibung: Intelligentes Batteriemanagement einschalten, wenn (minimaler SoC erreicht) UND (Stunden mit Prognose > maximale Einspeiseleistung) UND (Restleistung bis Sonnenuntergang – Restverbrauch – freie Batteriekapazität) > 0
+
+Details: 
+- Sind alle stundenweisen Prognosewerte kleiner als "Maximale Einspeisung", wird die KOSTAL-Steuerung nicht aktiviert. Die maximale Einspeisung wird hierbei um 15% geringer angenommen, um auch Schwankungen durch Wolken vorwegzunehmen.
+- Zwischen 15 Uhr und Sonnenaufgang wird die Einstellung der Intelligenten Steuerung von KOSTAL nicht verändert. Die KOSTAL-Steuerung scheint besser zu arbeiten, wenn sie nicht unnötig oft ein-/ausgeschaltet wird. In diesem Zeitraum hat die KOSTAL-Steuerung keinen Nachteil.
+- Es wird eine Hysterese verwendet, um seltener ein-/auszuschalten. Es wird ausgeschaltet, wenn der aktuelle SoC kleiner ist als der "Minimaler SoC zur Aktivierung des Batteriemanagements" oder wenn die freie Leistung unter 0 ist. Es wird eingeschaltet, wenn der aktuelle SoC größer ist als  "Minimaler SoC zur Aktivierung des Batteriemanagements"+1 und die freie Leistung größer als 10% der Batteriekapazität.
+
 ## Changelog
+
+### 2.2.2
+- Alternative intelligente Batteriestrategie hinzugefügt (Beschreibung siehe oben) [PastCoder]
 
 ### 2.2.1
 - Prognose-Zickzack behoben [PastCoder]

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -43,6 +43,12 @@
                 var id = $key.attr('id');
 				if (id === 'password') {
 					settings[id] = decrypt(secret, settings[id]);
+				} else if (id === 'battery_strategy') {
+					// select item from dropdown list
+					
+					var $sel = $('#' + id);
+					$sel.val(settings[id]);
+					$sel.select();
 				}
                 if ($key.attr('type') === 'checkbox') {
                     // do not call onChange direct, because onChange could expect some arguments

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -124,7 +124,7 @@
 					var value = $this.val();
 					if (id === 'password') {
 						value = encrypt(secret, value);
-					} else if(id === 'min_minsoc' || id === 'max_minsoc' || id === 'enable_bm_minsoc' || id === 'port') {
+					} else if(id === 'min_minsoc' || id === 'max_minsoc' || id === 'enable_bm_minsoc' || id === 'port'  || id === 'max_feed_in_power') {
 						value = parseInt(value);
 					}
 					obj[id] = value;
@@ -171,8 +171,8 @@
 				return;
 			}
 			
-			if(obj['max_feed_in_percentage'] < 30 || obj['max_feed_in_percentage'] > 100 ) {
-				showError(_('Please enter a maximum feed-in percentage between 30 and 100. Default is 70.'));
+			if(obj['max_feed_in_power'] < 0) {
+				showError(_('Please enter a maximum feed-in power bigger than 0. Default is 5000.'));
 				return;
 			}
 			
@@ -336,14 +336,22 @@
 				</div>
 				<div class="col s6 input-field">
 					<input type="number" class="value" id="min_minsoc" />
-					<label for="min_minsoc" class="translate">minimum minsoc</label>
+					<label for="" class="translate">minimum minsoc</label>
 					<p><small class="translate">min minsoc description</small></p>
 				</div>
 				<div class="col s6 input-field">
-					<input type="number" class="value" id="max_feed_in_percentage" />
-					<label for="max_feed_in_percentage" class="translate">maximum feed-in percentage</label>
+					<input type="number" class="value" id="max_feed_in_power" />
+					<label for="max_feed_in_power" class="translate">maximum feed-in power</label>
 					<p><small class="translate">max feed-in description</small></p>
 				</div>
+				<div class="col s6 input-field">
+					<select class="value" id="battery_strategy">
+					<option value="1">1: Double day forecast vs. battery capacity</option>
+					<option value="2">2: Remaining forecast vs. consumption and free battery capacity</option>
+					</select>
+					<label for="battery_strategy" class="translate">battery strategy</label>
+					<p><small class="translate">battery strategy description</small></p>
+				</div>			
 			</div>
 		</div>
 

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -357,7 +357,7 @@
 				</div>
 				<div class="col s6 input-field">
 					<input type="number" class="value" id="min_minsoc" />
-					<label for="" class="translate">minimum minsoc</label>
+					<label for="min_minsoc" class="translate">minimum minsoc</label>
 					<p><small class="translate">min minsoc description</small></p>
 				</div>
 				<div class="col s6 input-field">

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -99,23 +99,6 @@
 			}
 		}
 		
-		function fillInstances(id, arr, val, append) {
-            var $sel = $('#' + id);
-			if(!append) {
-	            $sel.html('<option value="">' + _('none') + '</option>');
-			}
-            for (var i = 0; i < arr.length; i++) {
-                var _id = arr[i]._id.replace('system.adapter.', '');
-				var _name = _id;
-				if(arr[i]._name) {
-					_name = arr[i]._name;
-				}
-                // Take first value
-                $sel.append('<option value="' + _id + '"' + ((_id === val) ? ' selected' : '') + '>' + _name + '</option>');
-            }
-            $sel.select();
-        }
-		
         // This will be called by the admin adapter when the settings page loads
         function load(settings, onChange) {
             // example: select elements with id=key and class=value and insert value

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -63,6 +63,18 @@
                     // do not call onChange direct, because onChange could expect some arguments
 					if(id === 'pollinterval' && !settings[id]) {
 						settings[id] = 60000;
+					} else if(id === 'max_feed_in_power' && !settings[id]) {
+						// Code to migrate from old setting max_feed_in_percentage (percentage limit) to new setting max_feed_in_power (absolute value)
+
+						if (settings['max_feed_in_percentage'] && settings['panel_surface'] && settings['panel_efficiency']) {
+							let wp = settings['panel_surface'] * 10 * settings['panel_efficiency']; // * 1000 / 100
+
+							if(settings['panel_surface_2'] && settings['panel_efficiency_2']) {
+								wp = wp + (settings['panel_surface_2'] * 10 * settings['panel_efficiency_2']);
+							}		
+						
+							settings[id] = wp * 100 / settings['max_feed_in_percentage'];
+						} 			
 					}
                     $key.val(settings[id])
                         .on('change', () => onChange())

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -194,6 +194,9 @@
 				return;
 			}
 			
+			// set all setting objects to null which were used in earlier versions of the adapter but are not used anymore.
+			obj['max_feed_in_percentage'] = null;
+			
             callback(obj);
         }
     </script>

--- a/admin/words.js
+++ b/admin/words.js
@@ -338,29 +338,29 @@ systemDictionary = {
 		"pl": "Definiuje minimalną wartość MinSoC ustawioną przez funkcję prognozy. Wartość domyślna to 40, możliwe wartości to od 5 do 100. Musi być niższa niż maksymalna wartość MinSoC",
 		"zh-cn": "定义由预测功能设置的最小MinSoC值。默认值为40，可能的值为5到100。必须小于最大MinSoC"
 	},
-	"maximum feed-in percentage": {
-		"en": "Maximum feed-in percentage (%)",
-		"de": "Maximale Einspeisung in Prozent (%)",
-		"ru": "Maksimal'nyy protsent podachi (%)",
-		"pt": "Porcentagem máxima de alimentação (%)",
-		"nl": "Maximaal terugleverpercentage (%)",
-		"fr": "Pourcentage d'alimentation maximal (%)",
-		"it": "Percentuale massima di immissione in rete (%)",
-		"es": "Porcentaje máximo de alimentación (%)",
-		"pl": "Maksymalny procent podawania (%)",
-		"zh-cn": "最大进料百分比 （％）"
+	"maximum feed-in power": {
+		"en": "Maximum feed-in power (W)",
+		"de": "Maximale Einspeisung (W)",
+		"ru": "Максимальная потребляемая мощность (W)",
+		"pt": "Potência máxima de alimentação (W)",
+		"nl": "Maximaal terugleververmogen (W)",
+		"fr": "Puissance d'alimentation maximale (W)",
+		"it": "Massima potenza di immissione (W)",
+		"es": "Potencia máxima de alimentación (W)",
+		"pl": "Maksymalna moc zasilania (W)",
+		"zh-cn": "最大馈电功率 （W）"
 	},
 	"max feed-in description": {
-		"en": "Defines the maximum percentage, which is can by feed-in (e.g. max. 70%)",
-		"de": "Definiert den Prozentsatz der maximalen Leistung, die eingespeist werden darf (z.B. max. 70% der Panel-Leistung)",
-		"ru": "Определяет процент максимальной мощности, которая может подаваться (например, макс. 70% мощности панели).",
-		"pt": "Define a porcentagem da potência máxima que pode ser alimentada (por exemplo, máx. 70% da potência do painel)",
-		"nl": "Bepaalt het percentage van het maximale vermogen dat mag worden teruggeleverd (bijv. max. 70% van het paneelvermogen)",
-		"fr": "Définit le pourcentage de la puissance maximale pouvant être injectée (par ex. max. 70 % de la puissance du panneau)",
-		"it": "Definisce la percentuale della potenza massima che può essere immessa (es. max. 70% della potenza del pannello)",
-		"es": "Define el porcentaje de la potencia máxima que se puede alimentar (por ejemplo, máx. 70% de la potencia del panel)",
-		"pl": "Określa procent maksymalnej mocy, jaka może być doprowadzona (np. maks. 70% mocy panelu)",
-		"zh-cn": "定义可以馈入的最大功率的百分比（例如，最大 70% 的面板功率）"
+		"en": "Defines the maximum power, which is can by feed-in (e.g. max. 70% of 10.000kWh peak --> 7000W)",
+		"de": "Definiert die maximale Leistung, die eingespeist werden darf (z.B. max. 70% von 10.000kWh Peakleistung --> 7000W)",
+		"ru": "Определяет максимальную мощность, которая может подаваться (например, макс. 70% пиковой мощности 10 000 кВтч --> 7000 Вт)",
+		"pt": "Define a potência máxima que pode ser alimentada (por exemplo, máx. 70% da potência de pico de 10.000kWh --> 7000W)",
+		"nl": "Definieert het maximale vermogen dat mag worden teruggeleverd (bijv. max. 70% van 10.000 kWh piekvermogen --> 7000W)",
+		"fr": "finit la puissance maximale pouvant être injectée (par ex. max. 70 % de la puissance de crête de 10 000 kWh --> 7 000 W)",
+		"it": "Definisce la potenza massima che può essere immessa (es. max. 70% di potenza di picco di 10.000 kWh --> 7000 W)",
+		"es": "Define la potencia máxima que se puede alimentar (p. ej., máx. 70 % de una potencia máxima de 10 000 kWh --> 7000 W)",
+		"pl": "Określa maksymalną moc, jaka może być podawana (np. maks. 70% mocy szczytowej 10 000 kWh --> 7000 W)",
+		"zh-cn": "定义可以馈入的最大功率（例如，最大 10,000kWh 峰值功率的 70% --> 7000W"
 	},
 	"The forecast uses weather data from kachelmannwetter and (if adapters installed) from weatherunderground.": {
 		"en": "The forecast uses weather data from kachelmannwetter and (if adapters installed) from weatherunderground, daswetter.com.",
@@ -457,6 +457,30 @@ systemDictionary = {
 		"es": "Con la gestión de la batería habilitada, es posible que la batería no se cargue por la mañana. Esto puede llevar a la energía extraída de la red cuando la batería se descargó durante la noche y hay un pico de consumo en la mañana que la planta de energía no puede cumplir. Aquí puede establecer un valor mínimo de SoC en el que se cargará la batería con la energía disponible de la planta, independientemente del estado de administración de la batería.",
 		"pl": "Przy włączonym zarządzaniu baterią bateria może nie być ładowana rano. Może to prowadzić do energii pobieranej z sieci, gdy akumulator był rozładowywany w nocy, a rano występuje szczyt zużycia, którego elektrownia nie może osiągnąć. Tutaj możesz ustawić minimalną wartość SoC, do której akumulator będzie ładowany przy dostępnej mocy instalacji, niezależnie od stanu zarządzania baterią.",
 		"zh-cn": "启用电池管理后，早上可能无法为电池充电。当电池在夜间放电时，这可能会导致从电网获取电力，而早晨则出现消耗高峰，这是发电厂无法满足的。在这里，您可以设置最小SoC值，而不管电池管理状态如何，都可以使用可用的工厂电源为电池充电。"
+	},
+	"battery strategy": {
+		"en": "Select battery strategy.",
+		"de": "Batteriestrategie auswählen.",
+		"ru": "Выберите стратегию батареи.",
+		"pt": "Selecione a estratégia da bateria.",
+		"nl": "Selecteer batterijstrategie.",
+		"fr": "Sélectionnez la stratégie de la batterie.",
+		"it": "Seleziona la strategia della batteria.",
+		"es": "Seleccione la estrategia de la batería.",
+		"pl": "Wybierz strategię baterii.",
+		"zh-cn": "选择电池策略。"
+	},
+	"battery strategy description": {
+		"en": "Strategy #1: Switch smart battery management on, if (minimum SoC is reached) AND (remaining power until sunset - remaining consumption - free battery capacity) >= 2 * battery capacity.       Strategy #2: Switch smart battery management on, if (minimum SoC is reached) AND (hours with forecast > maximum feedinpower) AND (remaining power until sunset - remaining consumption - free battery capacity) > 0",
+		"de": "Strategie #1: Intelligentes Batteriemanagement einschalten, wenn (Mindest-SoC erreicht) UND (Restleistung bis Sonnenuntergang – Restverbrauch – freie Batteriekapazität) >= 2 * Batteriekapazität. Strategie #2: Intelligentes Batteriemanagement einschalten, wenn (minimaler SoC erreicht) UND (Stunden mit Prognose > maximale Einspeiseleistung) UND (Restleistung bis Sonnenuntergang – Restverbrauch – freie Batteriekapazität) > 0",
+		"ru": "Стратегия № 1: включить интеллектуальное управление батареями, если (достигнут минимальный уровень SoC) И (остаточная мощность до захода солнца — оставшееся потребление — свободная емкость батареи) >= 2 * емкость батареи. Стратегия № 2: Включите интеллектуальное управление батареями, если (достигнут минимум SoC) И (количество часов с прогнозом > максимальной мощности питания) И (остаточная мощность до захода солнца — оставшееся потребление — свободная емкость батареи) > 0",
+		"pt": "Estratégia nº 1: Ative o gerenciamento inteligente de bateria, se (soC mínimo for atingido) E (energia restante até o pôr do sol - consumo restante - capacidade livre da bateria) >= 2 * capacidade da bateria. Estratégia nº 2: Ative o gerenciamento inteligente de bateria, se (soC mínimo for atingido) AND (horas com previsão > alimentação máxima de alimentação) AND (energia restante até o pôr do sol - consumo restante - capacidade livre da bateria) > 0",
+		"nl": "Strategie #1: Schakel slim batterijbeheer in, als (minimale SoC is bereikt) EN (resterend vermogen tot zonsondergang - resterend verbruik - vrije batterijcapaciteit) >= 2 * batterijcapaciteit. Strategie #2: Schakel slim batterijbeheer in, indien (minimale SoC is bereikt) AND (uren met voorspelling > maximaal voedingsvermogen) AND (resterend vermogen tot zonsondergang - resterend verbruik - vrije batterijcapaciteit) > 0",
+		"fr": "Stratégie n°1 : activez la gestion intelligente de la batterie si (le SoC minimum est atteint) ET (puissance restante jusqu'au coucher du soleil - consommation restante - capacité de la batterie libre) >= 2 * capacité de la batterie. Stratégie n°2 : activer la gestion intelligente de la batterie, si (le SoC minimum est atteint) ET (heures avec prévision > puissance d'alimentation maximale) ET (puissance restante jusqu'au coucher du soleil - consommation restante - capacité de batterie libre) > 0",
+		"it": "Strategie #1: attiva la gestione intelligente della batteria, se (viene raggiunto il minimo SoC) E (potenza residua fino al tramonto - consumo residuo - capacità della batteria libera) >= 2 * capacità della batteria. Strategia n. 2: attivare la gestione intelligente della batteria, se (viene raggiunto il minimo SoC) AND (ore con previsione > potenza massima di alimentazione) AND (potenza residua fino al tramonto - consumo residuo - capacità della batteria libera) > 0",
+		"es": "Strategia n. 1: active la administración inteligente de la batería si (se alcanza el SoC mínimo) Y (energía restante hasta la puesta del sol - consumo restante - capacidad libre de la batería) >= 2 * capacidad de la batería. Estrategia n.º 2: active la gestión inteligente de la batería si (se alcanza el SoC mínimo) Y (horas con previsión > potencia de alimentación máxima) Y (energía restante hasta la puesta del sol - consumo restante - capacidad libre de la batería) > 0",
+		"pl": "Strategia nr 1: Włącz inteligentne zarządzanie baterią, jeśli (osiągnięto minimalny SoC) ORAZ (pozostała moc do zachodu słońca - pozostałe zużycie - wolna pojemność baterii) >= 2 * pojemność baterii. Strategia nr 2: Włącz inteligentne zarządzanie baterią, jeśli (osiągnięto minimalny SoC) ORAZ (godziny z prognozą > maksymalna moc zasilania) ORAZ (pozostała moc do zachodu słońca - pozostały poziom zużycia - wolna pojemność baterii) > 0",
+		"zh-cn": "策略#1：开启智能电池管理，如果（达到最低 SoC）和（直到日落的剩余电量 - 剩余电量 - 可用电池容量）>= 2 * 电池容量。策略#2：开启智能电池管理，如果（达到最低 SoC）AND（预测小时数 > 最大供电）AND（剩余电量直到日落 - 剩余消耗 - 无电池容量）> 0"
 	},
 	"No location set in ioBroker system config": {
 		"en": "You have not set location info in the main system config of ioBroker. This adapter needs location information to work, so please set location info before starting it.",

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,20 @@
 {
 	"common": {
 		"name": "plenticore",
-		"version": "2.2.1",
+		"version": "2.2.2",
 		"news": {
+			"2.2.2": {
+				"en": "Added alternative smart battery strategy [PastCoder]",
+				"de": "Alternative intelligente Batteriestrategie hinzugefügt [PastCoder]",
+				"ru": "Добавлена ​​альтернативная стратегия умной батареи [PastCoder]",
+				"pt": "Adicionada estratégia alternativa de bateria inteligente [PastCoder]",
+				"nl": "Alternatieve slimme batterijstrategie toegevoegd [PastCoder]",
+				"fr": "Ajout d'une stratégie de batterie intelligente alternative [PastCoder]",
+				"it": "Aggiunta una strategia alternativa per la batteria intelligente [PastCoder]",
+				"es": "Se agregó una estrategia alternativa de batería inteligente [PastCoder]",
+				"pl": "Dodano alternatywną strategię inteligentnej baterii [PastCoder]",
+				"zh-cn": "添加了替代智能电池策略 [PastCoder]"
+			},
 			"2.2.1": {
 				"en": "Fixed forecast zickzack [PastCoder]",
 				"de": "Prognose-Zickzack behoben [PastCoder]",
@@ -231,7 +243,8 @@
 		"panel_dir": 180,
 		"panel_surface": 0,
 		"panel_efficiency": 19.2,
-		"max_feed_in_percentage": 70
+		"max_feed_in_power": 5000,
+		"battery_strategy" : "1"
 	},
 	"objects": [],
 	"instanceObjects": [

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -816,9 +816,9 @@ function getMaxFeedInPower() {
 
 	// Code to migrate from old setting max_feed_in_percentage (percentage limit) to new setting max_feed_in_power (absolute value)
 	if (!adapter.config.max_feed_in_power) {
-		if (adapter.max_feed_in_percentage) {
+		if ( (adapter.config.max_feed_in_percentage) && (adapter.config.max_feed_in_percentage != null) ) {
 			// if the new config value is missing but the old is there, calculate absolute value from percentage
-			power = getPanelWp() * 100 / adapter.max_feed_in_percentage;
+			power = getPanelWp() * 100 / adapter.config.max_feed_in_percentage;
 		} else {
 			// If both values are not there, take an very high value (3x the panel power). In this case no feed-in limit will be assumed.
 			power = 3 * getPanelWp();

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -23,7 +23,8 @@ let pollingTime;
 let PVStringCount = 2;
 let hasBattery = false;
 let panelWp = 0;
-let maxFeedInFactor = 0.7;
+let maxFeedInPower = 5000;
+let batteryStrategy = '1';
 
 let consumptionData = {};
 let generationData = {};
@@ -646,10 +647,12 @@ function init(adapterInstance, utilsInstance, weatherInstance) {
 
 function setup(callback) {
 	panelWp = getPanelWp();
-	maxFeedInFactor = getMaxFeedInFactor();
+	maxFeedInPower = getMaxFeedInPower();
+	batteryStrategy = getBatteryStrategy();
 
 	adapter.log.info('Configured Wp of panel(s) is ' + Math.round(panelWp));
-	adapter.log.info('Configured maximum feed-in factor is ' + maxFeedInFactor);
+	adapter.log.info('Configured maximum feed-in power is ' + maxFeedInPower);
+	adapter.log.info('Configured battery strategy is: ' + batteryStrategy);
 
 	deviceIpAdress = adapter.config.ipaddress;
 	devicePort = adapter.config.port;
@@ -808,10 +811,16 @@ function getPanelWp() {
 	return wp;
 }
 
-function getMaxFeedInFactor() {
-	let factor = adapter.config.max_feed_in_percentage / 100  // translate percentage to factor
+function getMaxFeedInPower() {
+	let power = adapter.config.max_feed_in_power;
 
-	return factor;
+	return power;
+}
+
+function getBatteryStrategy() {
+	let strategy = adapter.config.battery_strategy;
+	
+	return strategy;
 }
 
 
@@ -2027,7 +2036,7 @@ function calcMinSoC(forecastRead, tomorrow) {
 		add_id = '.day2';
 	}
 
-	let enable_smart_battery_control = false;
+	let feed_in_limitation_expected = false;
 	let sun_hour = 0;
 	let sun_hour_step = 0;
 	let sunhour_starts = {};
@@ -2284,9 +2293,15 @@ function calcMinSoC(forecastRead, tomorrow) {
 					//
 					// Derive status for the smart battery management 
 					//
-					if(fcPower > panelWp * maxFeedInFactor) {     // the forecasted power is higher that than the power that is allowed to feed-in
-						adapter.log.debug('(battery management) fcPower ' + fcPower + ' for hour ' + shindex + ' exceeds maximum feed-in power ' + (panelWp * maxFeedInFactor) + ' setting enable_smart_battery_control to true.');
-						enable_smart_battery_control = true;  // in this case the smart battery management _could_ make sense
+					if (factor > 0) {    // only if the period is relevant
+						// Check if the forecasted power is higher than the power that is allowed to feed-in
+						// 10% are added as margin because the power may not be distributed evenly within the hour. There might be phases with higher power, even if the average is below the limit.
+						// In this place we can be quite offensive in enabling the smart battery control. In later places of the strategy (see below) it will be disabled if not enough energy is remaining for the day.
+						// Setting feed_in_limitation_expected here is relevant only for strategy #2. For strategy #1 does not consider it.
+						if( fcPower > (maxFeedInPower * 0.85) ) {     
+							adapter.log.debug('(battery management) fcPower ' + fcPower + ' for hour ' + shindex + ' (starts at ' + time + ') exceeds maximum feed-in power (with 15% margin) ' + (maxFeedInPower * 0.85) + ' setting feed_in_limitation_expected to true.');
+							feed_in_limitation_expected = true;  // in this case the smart battery management _may_ make sense
+						}
 					}
 				}
 			}
@@ -2369,23 +2384,50 @@ function calcMinSoC(forecastRead, tomorrow) {
 							power_plus = 0;
 						}
 
-						adapter.log.debug('Checking battery management: ' + power_plus + ' = ' + powerUntilSunset + ' - ' + daily_cons + ' + ' + curSoC + ' - ' + adapter.config.battery_capacity + ' > ' + panelWp + ' * ' + maxFeedInFactor + ' (' + (panelWp * maxFeedInFactor) + ') -> ' + enable_smart_battery_control);
-						/*if(power_plus <= panelWp * maxFeedInFactor) {
-							enable_smart_battery_control = false;
-						} else if(curSoCPercentage < adapter.config.enable_bm_minsoc) {
-							enable_smart_battery_control = false;
-						}*/
-						
-						// Strategy_1
-						if(parseInt(curSoCPercentage) < parseInt(curMinSoC) + 8) {  
-							adapter.log.info('Strategy #1: Disabling battery management because ' + curMinSoC + ' is too high for current SoC ' + curSoCPercentage);
-							setSmartBatteryControl(false);
-						} else if(power_plus >= 2 * adapter.config.battery_capacity) {
-							setSmartBatteryControl(true);
-						} else {
-							setSmartBatteryControl(false);
-						}
+						adapter.log.info('Calculated remaining energy: ' + power_plus + ' (power_plus = powerUntilSunset - daily_cons + curSoC - adapter.config.battery_capacity)');
 
+						// Switch smart battery control; depending on the battery strategy selected in the adapter settings
+						if (batteryStrategy == '2') {
+							// Change the setting only between sunrise and 3pm. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
+							if ( (timeNow.getHours() < 15) && (timeNow > sunrise) ) {
+								
+								// if the forecast does not see a risk of exceeding the limit: switch off
+								if (feed_in_limitation_expected == false) {
+									setSmartBatteryControl(false);
+									adapter.log.info('Strategy #2: setSmartBatteryControl(false). feed_in_limitation_expected: false');
+								} else {
+									// Use a hysteresis for curSoCPercentage and power_plus to avoid frequent switching on/off if curSoCPercentage is around adapter.config.enable_bm_minsoc or power_plus is around 0.
+									// The following table shows the decision logic
+									//                                                                    |  curSoCPercentage <= enable_bm_minsoc-1 | enable_bm_minsoc-1 < curSoCPercentage < enable_bm_minsoc+2  | enable_bm_minsoc+2 <= curSoCPercentage
+									//                            power_plus <= 0                         |           switch off                    |                      switch off                             |                switch off
+									//                        0 < power_plus <= 10% of battery_capacity   |           switch off                    |                      don't switch                           |                don't switch
+									//  10% of battery_capacity < power_plus                              |           switch off                    |                      don't switch                           |                switch on
+									if ( (curSoCPercentage < adapter.config.enable_bm_minsoc) || (power_plus < 0) ) {
+										// first column and first row in the comment above
+										setSmartBatteryControl(false);
+										adapter.log.info('Strategy #2: setSmartBatteryControl(false). curSoCPercentage: ' + curSoCPercentage + '  power_plus: ' + power_plus);
+									} else if ( (curSoCPercentage >= adapter.config.enable_bm_minsoc+2) && (power_plus > adapter.config.battery_capacity * 0.1) ) {
+										// bottom right cell in the comment above
+										setSmartBatteryControl(true);
+										adapter.log.info('Strategy #2: setSmartBatteryControl(true). curSoCPercentage: ' + curSoCPercentage + '  power_plus: ' + power_plus);
+									} else {
+										// do not switch in all other cases
+										adapter.log.info('Strategy #2: SmartBatteryControl UNCHANGED. curSoCPercentage: ' + curSoCPercentage + '  power_plus: ' + power_plus);
+									}
+								}
+							}
+						} else {  
+							// Strategy_1
+							if(parseInt(curSoCPercentage) < parseInt(curMinSoC) + 8) {  
+								adapter.log.info('Strategy #1: Disabling battery management because ' + curMinSoC + ' is too high for current SoC ' + curSoCPercentage);
+								setSmartBatteryControl(false);
+							} else if(power_plus >= 2 * adapter.config.battery_capacity) {
+								setSmartBatteryControl(true);
+							} else {
+								setSmartBatteryControl(false);
+							}
+						}
+						
 						// publish power_plus
 						ioBLib.createOrSetState('forecast.consumption.power_plus', {
 							type: 'state',

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -814,6 +814,17 @@ function getPanelWp() {
 function getMaxFeedInPower() {
 	let power = adapter.config.max_feed_in_power;
 
+	// Code to migrate from old setting max_feed_in_percentage (percentage limit) to new setting max_feed_in_power (absolute value)
+	if (!adapter.config.max_feed_in_power) {
+		if (adapter.max_feed_in_percentage) {
+			// if the new config value is missing but the old is there, calculate absolute value from percentage
+			power = getPanelWp() * 100 / adapter.max_feed_in_percentage;
+		} else {
+			// If both values are not there, take an very high value (3x the panel power). In this case no feed-in limit will be assumed.
+			power = 3 * getPanelWp();
+		}
+	}
+
 	return power;
 }
 

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2375,26 +2375,16 @@ function calcMinSoC(forecastRead, tomorrow) {
 						} else if(curSoCPercentage < adapter.config.enable_bm_minsoc) {
 							enable_smart_battery_control = false;
 						}*/
-						if(parseInt(curSoCPercentage) < parseInt(curMinSoC) + 8) {
-							adapter.log.info('Disabling battery management because ' + curMinSoC + ' is too high for current SoC ' + curSoCPercentage);
-							enable_smart_battery_control = false;
+						
+						// Strategy_1
+						if(parseInt(curSoCPercentage) < parseInt(curMinSoC) + 8) {  
+							adapter.log.info('Strategy #1: Disabling battery management because ' + curMinSoC + ' is too high for current SoC ' + curSoCPercentage);
+							setSmartBatteryControl(false);
 						} else if(power_plus >= 2 * adapter.config.battery_capacity) {
-							enable_smart_battery_control = true;
+							setSmartBatteryControl(true);
 						} else {
-							enable_smart_battery_control = false;
+							setSmartBatteryControl(false);
 						}
-
-						// write battery.SmartBatteryControl
-						adapter.getState('devices.local.battery.SmartBatteryControl', function(err, state) {
-							if(!err) {
-								let curValue = (state ? state.val : null);
-
-								if(curValue === null || curValue !== enable_smart_battery_control) {
-									adapter.log.info((enable_smart_battery_control ? 'Enabling' : 'Disabling') + ' smart battery control feature in converter.');
-									adapter.setState('devices.local.battery.SmartBatteryControl', enable_smart_battery_control, false);
-								}
-							}
-						});
 
 						// publish power_plus
 						ioBLib.createOrSetState('forecast.consumption.power_plus', {
@@ -2939,6 +2929,20 @@ function updatePowerConsumption(state) {
 	consumptionData[dn][0].consumption = power_sum;
 
 	calcPowerAverages(); // no rotating please!
+}
+
+function setSmartBatteryControl(value) {
+	// write battery.SmartBatteryControl
+	adapter.getState('devices.local.battery.SmartBatteryControl', function(err, state) {
+		if(!err) {
+			let curValue = (state ? state.val : null);
+
+			if(curValue === null || curValue !== value) {
+				adapter.log.info((value ? 'Enabling' : 'Disabling') + ' smart battery control feature in converter.');
+				adapter.setState('devices.local.battery.SmartBatteryControl', value, false);
+			}
+		}
+	});
 }
 
 function updateBatteryCharging(state) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.plenticore",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "plenticore",
   "author": {
     "name": "Marius Burkard",


### PR DESCRIPTION
This time a little bigger change - actually it is not a change but an addition. 

I propose an alternative strategy when to switch on/off the KOSTAL Smart Battery Management. The main information about the strategy is added in Readme.md and Readme_de.md. I've added there a section "Smart battery control". 
The new strategy is added as option which can be selected in the adapter settings. The default strategy is the previous strategy. 

 (!) There is one change in the settings compare to the current github version: I changed the setting for the feed-in limitation from a percentage to an absolute value. It give a little more flexibility (e.g. if the actually panel efficiency is different from the nominal one). 

I am using this strategy since a while now and it seems to work quite well. 

 (!) There is one thing which I did not manage: When you open the adapter settings, it shown always strategy 1 as current selection. I did nit figute out how to set the dropdown list to the previously select value when loading the settings. 

When transferring the implementation from my experimental branch to this proposed one, I split the changes in three pull request: 
- Adjustment of the settings
- Extract code into the function setSmartBatteryControl() to make the code a little more readable 
- Addition of the strategy 2

Test usual: Additional testing and feedback welcome :-)  I am using strategy 2 so that this one wil lbe tested anyhow (at least with my setup).