### PR TITLE
Strategy 2 allow smart switch after 3pm

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2400,9 +2400,8 @@ function calcMinSoC(forecastRead, tomorrow) {
 
 						// Switch smart battery control; depending on the battery strategy selected in the adapter settings
 						if (batteryStrategy == '2') {
-							// Change the setting only between sunrise and 3 hours before sunset. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
-							if ( (timeNow.getTime() < (sunset.getTime() - 3*60*60*1000)) && (timeNow > sunrise) ) {
-								
+							// Do not change smart setting in last 1/4 between sunrise and sunset. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
+							if ( (timeNow.getTime() < (sunset.getTime() - 0.25 * (sunset.getTime() - sunrise.getTime()))) && (timeNow > sunrise) ) {						
 								// if the forecast does not see a risk of exceeding the limit: switch off
 								if (feed_in_limitation_expected == false) {
 									setSmartBatteryControl(false);

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2401,7 +2401,7 @@ function calcMinSoC(forecastRead, tomorrow) {
 						// Switch smart battery control; depending on the battery strategy selected in the adapter settings
 						if (batteryStrategy == '2') {
 							// Change the setting only between sunrise and 3 hours before sunset. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
-							if ( (timeNow.getTime() < (sunrise.getTime() - 3*60*60*1000)) && (timeNow > sunrise) ) {
+							if ( (timeNow.getTime() < (sunset.getTime() - 3*60*60*1000)) && (timeNow > sunrise) ) {
 								
 								// if the forecast does not see a risk of exceeding the limit: switch off
 								if (feed_in_limitation_expected == false) {

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2401,7 +2401,8 @@ function calcMinSoC(forecastRead, tomorrow) {
 						// Switch smart battery control; depending on the battery strategy selected in the adapter settings
 						if (batteryStrategy == '2') {
 							// Change the setting only between sunrise and 3pm. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
-							if ( (timeNow.getHours() < 15) && (timeNow > sunrise) ) {
+//TODONN Test with changes in the afternoon		if ( (timeNow.getHours() < 15) && (timeNow > sunrise) ) {
+							if (timeNow > sunrise) {
 								
 								// if the forecast does not see a risk of exceeding the limit: switch off
 								if (feed_in_limitation_expected == false) {

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -2400,9 +2400,8 @@ function calcMinSoC(forecastRead, tomorrow) {
 
 						// Switch smart battery control; depending on the battery strategy selected in the adapter settings
 						if (batteryStrategy == '2') {
-							// Change the setting only between sunrise and 3pm. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
-//TODONN Test with changes in the afternoon		if ( (timeNow.getHours() < 15) && (timeNow > sunrise) ) {
-							if (timeNow > sunrise) {
+							// Change the setting only between sunrise and 3 hours before sunset. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
+							if ( (timeNow.getTime() < (sunrise.getTime() - 3*60*60*1000)) && (timeNow > sunrise) ) {
 								
 								// if the forecast does not see a risk of exceeding the limit: switch off
 								if (feed_in_limitation_expected == false) {


### PR DESCRIPTION
Just a small change for strategy 2. 
Before it did not switch the smart battery management after 3pm. Now this depends on the time of sunset and number of sun hours. It does not switch anymore in the last quarter of sun hours.
This gave better results when to switch and when not to switch anymore.