### PR TITLE
fix: re-login on network errors + daswetter v4 compatibility

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -56,20 +56,15 @@ let weatherAdapters = {
 	},*/
 	'daswetter': {
 		'instance': null,
-		'sky': 'clouds_value',
-		'time': 'hour_value',
+		'sky': 'clouds',
+		'time': 'time',
 		'visibility': null,
-		'rain': 'rain_value',
+		'rain': 'rain',
 		'rainChance': null,
-		'fc_id': 'NextHours.Location_1.Day_%%D%%.Hour_%%H%%',
+		'fc_id': 'location_1.ForecastHourly.Hour_%%H%%',
 		'fc_min': 1,
-		'fc_max': 3,
-		'fc_steps': {
-			'1': 1,
-			'2': 1,
-			'3': 3
-		},
-		'fc_mode': 'dayhours'
+		'fc_max': 24,
+		'fc_mode': 'hours'
 	}
 };
 let forecastData = {};
@@ -1626,8 +1621,12 @@ function apiCall(method, endpoint, data, callback) {
 		response.on('end', function() {
 			adapter.log.debug('Result of request: ' + JSON.stringify({code: code, headers: headers, body: body}));
 			if(code === 401 || code === 403) {
-				adapter.log.debug('Request failed: ' + JSON.stringify({code: code, headers: headers, body: body}));
-				adapter.terminate && adapter.terminate() || process.exit();
+				adapter.log.warn('Session expired or unauthorized (HTTP ' + code + '), triggering re-login...');
+				loginSessionId = null;
+				if(polling) { clearTimeout(polling); polling = null; }
+				login(function() {
+					adapter.log.info('Re-login after 401/403 successful, resuming polling.');
+				});
 				return;
 			}
 			callback && callback(body, code, headers);
@@ -3377,6 +3376,16 @@ function pollStates(pollingTime) {
 	apiCall('POST', 'processdata', payload, function(body, code, headers) {
 		if(code === 200) {
 			processDataResponse(body, 'processdata');
+		} else if(code === 0) {
+			adapter.log.warn('Processdata request failed: network error (code 0) — triggering re-login in 15s');
+			loginSessionId = null;
+			if(polling) { clearTimeout(polling); polling = null; }
+			polling = setTimeout(function() {
+				login(function() {
+					adapter.log.info('Re-login after network error successful, resuming polling.');
+				});
+			}, 15000);
+			return;
 		} else {
 			adapter.log.warn('Requesting processdata - ' + JSON.stringify(payload) + ') failed with code ' + code + ': ' + body);
 		}

--- a/lib/weather.js
+++ b/lib/weather.js
@@ -322,6 +322,52 @@ function normalizeRainData(type) {
 	}
 }
 
+
+async function getRainDataFromDaswetter() {
+	try {
+		const now = new Date();
+		const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		let filled = 0;
+		for(let h = 1; h <= 24; h++) {
+			const stateId = 'daswetter.0.location_1.ForecastHourly.Hour_' + h + '.rain';
+			const timeId  = 'daswetter.0.location_1.ForecastHourly.Hour_' + h + '.time';
+			let rainState, timeState;
+			try {
+				rainState = await new Promise((res, rej) => adapter.getForeignState(stateId, (err, s) => err ? rej(err) : res(s)));
+				timeState = await new Promise((res, rej) => adapter.getForeignState(timeId,  (err, s) => err ? rej(err) : res(s)));
+			} catch(e) {
+				adapter.log.debug('daswetter rain: could not get state ' + stateId + ': ' + e);
+				continue;
+			}
+			if(!rainState || rainState.val === null || rainState.val === undefined) continue;
+			if(!timeState || !timeState.val) continue;
+			const parts = String(timeState.val).split(':');
+			if(parts.length < 2) continue;
+			const hh = parseInt(parts[0], 10);
+			const mm = parseInt(parts[1], 10);
+			const timestamp = today.getTime() + hh * 3600000 + mm * 60000;
+			const hindex = getHourForTime(timestamp);
+			if(hindex === null) continue;
+			const key = hindex + 'h';
+			for(const tindex of ['primary', 'secondary']) {
+				if(!forecastHours[tindex][key]) continue;
+				if(forecastHours[tindex][key]['rain'] === null) {
+					forecastHours[tindex][key]['rain'] = parseFloat(rainState.val);
+					if(!forecastHours[tindex][key]['time']) {
+						forecastHours[tindex][key]['time'] = timestamp;
+					}
+					filled++;
+				}
+			}
+		}
+		adapter.log.info('daswetter rain data: filled ' + filled + ' forecast hours');
+		return true;
+	} catch(e) {
+		adapter.log.warn('getRainDataFromDaswetter failed: ' + e);
+		return false;
+	}
+}
+
 function getRainData(body, second) {
     let match = body.match(/var\s*hccompact_data_rain\s*=\s*\[[\s\S]*?name:\s*'(Regen|Schnee)'[\s\S]*?data:\s*(\[[\s\S]*?\]\s*\])\s*,\s*[\s\S]*?\}\s*\}\s*(?:,\s*\{[\s\S]*?name:\s*'(Regen|Schnee)'[\s\S]*?data:\s*(\[[\s0\S]*?\]\s*\])\s*,[\s\S]*?\s*\})\s*\]\s*;/);
     if(match && match.length > 0) {
@@ -502,10 +548,11 @@ function getJSONData(callback) {
 				adapter.log.warn('Could not process weather data.');
 			}
 
-			ok = getRainData(body);
-			if(!ok) {
-				adapter.log.warn('Could not process weather data (rain).');
-			}
+			getRainDataFromDaswetter().then(function(ok) {
+				if(!ok) {
+					adapter.log.warn('Could not process weather data (rain) from daswetter.');
+				}
+			});
 
 			ok = getRainChanceData(body);
 			if(!ok) {
@@ -526,10 +573,7 @@ function getJSONData(callback) {
 						adapter.log.warn('Could not process weather data.');
 					}
 
-					ok = getRainData(body, true);
-					if(!ok) {
-						adapter.log.warn('Could not process weather data (rain).');
-					}
+					// rain data filled by getRainDataFromDaswetter (called above, shared forecastHours)
 
 					ok = getRainChanceData(body, true);
 					if(!ok) {


### PR DESCRIPTION
## Summary

This PR fixes three bugs found by analyzing a production system with recurring 12-hour data gaps in ioBroker history.

---

### Fix 1: Re-login on HTTP 401/403 instead of terminating (`plenticore.js`)

**Problem:** Any `401/403` response from the inverter called `adapter.terminate()`, causing a full adapter restart (~7 seconds downtime) every time the Kostal inverter invalidated the session (e.g. after network interruption or nightly session timeout).

**Fix:** Clear `loginSessionId` and call `login()` directly — polling resumes without any restart.

---

### Fix 2: Re-login on network errors (code=0) instead of silent data loss (`plenticore.js`)

**Problem:** When a network error occurred (TCP timeout, connection reset, WiFi repeater disconnect), `apiCall()` returned `code=0`. The `pollStates()` function silently skipped `processDataResponse()` but kept the polling timer running — the adapter appeared healthy in ioBroker while writing **no data for hours**.

Observed on a production system: a 30-second WiFi repeater reconnect caused a **12-hour data gap** because the adapter never recovered its session.

**Fix:** On `code=0`, clear session, wait 15s, trigger fresh `login()`. A warning log message makes the event visible.

---

### Fix 3: daswetter v4 (2026 API) compatibility (`plenticore.js` + `weather.js`)

As reported in #147 — the daswetter adapter v4 changed its object structure completely:

| | Old (broken) | New (v4) |
|---|---|---|
| Path | `NextHours.Location_1.Day_X.Hour_Y.*` | `location_1.ForecastHourly.Hour_Y.*` |
| Rain field | `rain_value` | `rain` |
| Sky field | `clouds_value` | `clouds` |
| Time field | `hour_value` | `time` |
| fc_mode | `dayhours` | `hours` |

Updated `weatherAdapters` config in `plenticore.js` and replaced the broken Kachelmann rain scraping with a new `getRainDataFromDaswetter()` function that reads rain data directly from daswetter ioBroker states.

Eliminates the recurring warnings:
```
warn: Processing rain data failed
warn: Could not process weather data (rain)
```

---

## Test environment

- ioBroker js-controller: 7.0.6 / 7.0.7
- plenticore adapter: 2.3.2
- daswetter adapter: 4.5.3
- Node.js: v22.15.0
- Inverter: Kostal Plenticore Plus
- Syntax checked: `node --check` passes on both files

## Related issues

Fixes #147 (daswetter v4 compatibility)